### PR TITLE
Added default value to queryParam and header

### DIFF
--- a/src/app/libs/dummy-helpers.lib.ts
+++ b/src/app/libs/dummy-helpers.lib.ts
@@ -5,12 +5,12 @@ export const DummyJSONHelpers = (request) => {
       return request.params[paramName];
     },
     // use params from query string ?param1=xxx&param2=yyy
-    queryParam: (paramName) => {
-      return request.query[paramName];
+    queryParam: (paramName, defaultValue) => {
+      return request.query[paramName] || defaultValue;
     },
     // use content from request header
-    header: (headerName) => {
-      return request.get(headerName);
+    header: (headerName, defaultValue) => {
+      return request.get(headerName) || defaultValue;
     },
     // use request hostname
     hostname: () => {


### PR DESCRIPTION
Add a default value the `queryParam` and `header`.

This allows for configuring query params like `limit` but give it a default if not passed.

**Mockoon**

```
{
  "data": [
      {{#repeat (queryParam 'limit' 5)}}
        {
            "name": "{{firstName}} {{lastName}}",
        }
      {{/repeat}}
  ]
}
```

**Without Param**

**URL:** `localhost:3030/contacts/`

```json
{
    "data": [
        {
            "name": "Cecilia Higgins"
        },
        {
            "name": "Drew Coolidge"
        },
        {
            "name": "Benito Mullens"
        },
        {
            "name": "Katelin Carroll"
        },
        {
            "name": "Florance Castleman"
        }
    ]
}
```

**With Param**

**URL:** `localhost:3030/contacts/?limit=2`

```json
{
    "data": [
        {
            "name": "Cory Chapman"
        },
        {
            "name": "Lorelei White"
        }
    ]
}
```