### PR TITLE
Pretty-print JSON bodies

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -290,7 +290,9 @@
                 <div class="row transition flex-fill" *ngIf="currentRoute" [ngClass]="{'dimmed': currentRoute.route.file}">
                   <div class="col d-flex flex-column">
                     <div class="title-separator has-icon">
-                      <div class="title-separator-icon text-secondary"><i class="material-icons">subject</i></div>
+                      <div class="title-separator-icon text-secondary">
+                        <span (click)="formatBody()"><i class="material-icons">subject</i></span>
+                      </div>
                       <div class="title-separator-text">
                         <div>Body </div>
                         <div *ngIf="currentRoute && currentRoute.route.file" class="text-warning">A file is selected, this body will not be served</div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -747,4 +747,21 @@ export class AppComponent implements OnInit {
   public addCORSHeadersToEnvironment() {
     this.environmentsService.setEnvironmentCORSHeaders(this.currentEnvironment.environment);
   }
+
+  /**
+   * If the body is set and the Content-Type is application/json, then prettify the JSON.
+   */
+  public formatBody() {
+    if (! this.currentRoute.route.body) {
+      return;
+    }
+    const contentType = this.getRouteContentType(this.currentEnvironment.environment, this.currentRoute.route);
+    if (contentType === 'application/json') {
+      try {
+        this.currentRoute.route.body = JSON.stringify(JSON.parse(this.currentRoute.route.body), undefined, 2);
+      } catch (e) {
+        // ignore any errors with parsing / stringifying the JSON
+      }
+    }
+  }
 }


### PR DESCRIPTION
I was missing the feature to "pretty-print" a copy/pasted JSON body within Mockoon. So I added it on click of the "body" icon, because it was one of the things I tried clicking on when looking for this feature.